### PR TITLE
Add the new hub logo to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-## Hub
-
-Hub
+<div align="center">
+    <img src="https://github.com/frappe/design/blob/master/logos/hub-logo.svg" height="128">
+    <h2>Hub</h2>
+</div>
 
 #### License
 


### PR DESCRIPTION
This PR adds the new hub logo to the README
![screenshot_20180130_181647](https://user-images.githubusercontent.com/9101092/35567081-bc9f3176-05e9-11e8-97e0-c1f56c215830.png)
